### PR TITLE
fixing offsets for A15 iOS 18.5

### DIFF
--- a/kexploit/offsets.m
+++ b/kexploit/offsets.m
@@ -525,12 +525,12 @@ void offsets_init(void) {
         off_thread_ro_tro_proc = 0x18;  //18.0-18.7
         off_thread_ro_tro_task = 0x28;  //18.0-18.7
         off_thread_machine_upcb = 0xb8; //different PER DEVICES; A12+, A17+, A10
-        off_thread_machine_contextdata = 0xb8-8;    //different PER DEVICES; A12+, A17+, A10
+        off_thread_machine_contextdata = 0xb0;    //different PER DEVICES; A12+, A17+, A10
         off_thread_t_tro = 0x378;   //different PER DEVICES; A12, A13+, A15+, A17, A18, A10
         off_thread_ctid = 0x428;    //different PER DEVICES; A12, A13+, A15+, A17, A18, A10
         off_thread_options = 0x70;  //different PER DEVICES; A12+, A17+, A10
         off_thread_mutex_lck_mtx_data = 0x3a0+8;    //different PER DEVICES; A12, A13+, A15+, A17, A18, A10
-        off_thread_machine_kstackptr = 0xF0;    //different PER DEVICES; A12, A13+, A17+, A10
+        off_thread_machine_kstackptr = 0xF8;    //different PER DEVICES; A12, A13+, A17+, A10
         off_thread_machine_jop_pid = 0x160;     //different PER DEVICES; A12, A13+, A15+, A17+
         off_thread_machine_rop_pid = 0x160-8;   //different PER DEVICES; A12, A13+, A15+, A17+
         off_thread_guard_exc_info_code = 0x320; //different PER DEVICES; A12, A13+, A15, A17, A18, A10
@@ -545,7 +545,7 @@ void offsets_init(void) {
         off_proc_p_textvp = 0x548;  //18.0-18.7
         off_proc_p_name = 0x57d;    //18.0-18.7
         off_proc_ro_pr_task = 0x8;  //18.0-18.7
-        off_proc_ro_p_ucred = 0x20;     //18.0-18.3.x
+        off_proc_ro_p_ucred = 0x20;     //18.0-18.3.x                               
         off_ucred_cr_label = 0x78;      //18.0-18.7
         off_task_itk_space = 0x318; //18.0-18.7; same PER DEVICES;
         off_task_threads_next = 0x50;   //18.0-18.7
@@ -573,7 +573,7 @@ void offsets_init(void) {
         off_arm_saved_state64_pc = 0x100;   //18.0-18.7
         off_arm_saved_state_uss_ss_64 = 0x8;    //18.0-18.7
         off_ipc_space_is_table = 0x20;  //18.0-18.7
-        off_ipc_entry_ie_object = 0;    //18.0-18.7
+        off_ipc_entry_ie_object = 0x0;    //18.0-18.7
         off_ipc_port_ip_kobject = 0x48; //18.0-18.7
         off_arm_kernel_saved_state_sp = 0x60;   //18.0-18.7
         off_vm_map_hdr = 0x10;  //18.0-18.7
@@ -606,7 +606,7 @@ void offsets_init(void) {
             off_thread_ctid = 0x440;
             off_thread_mutex_lck_mtx_data = 0x3B8+8;
             off_thread_machine_jop_pid = 0x170;
-            off_thread_machine_rop_pid = 0x170-8;
+            off_thread_machine_rop_pid = 0x168;
             off_thread_guard_exc_info_code = 0x338;
             off_thread_ast = 0x3b4;
             off_thread_task_threads_next = 0x380;
@@ -703,7 +703,7 @@ void offsets_init(void) {
     
     // iOS 18.4-18.5
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"18.4")) {
-        off_thread_guard_exc_info_code = 0xdeaddead;    //no more exist, renamed to mach_exc_info.code
+        off_thread_guard_exc_info_code = 0xDEADDEAD;    //no more exist, renamed to mach_exc_info.code
         off_proc_ro_p_ucred = 0x28; //18.4-18.7
 
         off_thread_t_tro = 0x378;
@@ -730,10 +730,10 @@ void offsets_init(void) {
         if(isA15Above) {
             off_thread_t_tro = 0x390;
             off_thread_ctid = 0x448;
-            off_thread_mutex_lck_mtx_data = 0x3B8+8;
+            off_thread_mutex_lck_mtx_data = 0x3C0;
             off_thread_mach_exc_info_code = 0x340;
-            off_thread_mach_exc_info_os_reason = 0x340-8;
-            off_thread_mach_exc_info_exception_type = 0x340-4;
+            off_thread_mach_exc_info_os_reason = 0x338;
+            off_thread_mach_exc_info_exception_type = 0x33C;
             off_thread_ast = 0x3B4;
             off_thread_task_threads_next = 0x380;
             off_task_task_exc_guard = 0x624;


### PR DESCRIPTION
I had frequent kernel panics on my 13 Pro on 18.5, so I decided to copy offsets from lara kexploit. Now it escapes the sandbox much faster (I don't have to keep reloading, as soon as the interface loads, it's already done), I tried to launch it like 50 times and it doesn't kernel panic. Even if it rarely fails and hangs on a black screen, I can just kill the app and restart it, it won't crash the whole thing. I also noticed now it lets me copy folders owned by _installd, which before it would deny or straight up cause a kernel panic.